### PR TITLE
Fix absolute URL for dropdown-menu.js

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,5 +1,5 @@
 exports.documentReady = function(){
-  $.getScript("/static/plugins/ep_aa_file_menu_toolbar/static/js/lib/jquery-css-dropdown-plugin-master/dropdown-menu.js", function(){
+  $.getScript("../static/plugins/ep_aa_file_menu_toolbar/static/js/lib/jquery-css-dropdown-plugin-master/dropdown-menu.js", function(){
     $(function() {
       $('.dropdown-menu').dropdown_menu({
         open_delay  : 50, // Delay on menu open


### PR DESCRIPTION
When having etherpad behind a proxy with an URL like
example.com/epl/, the absolute URL make ep_file_menu_toolbar fail to work.
