### PR TITLE
Changed the 'Strikethrough' data-key to 'strikethrough'

### DIFF
--- a/templates/toolbar.ejs
+++ b/templates/toolbar.ejs
@@ -43,7 +43,7 @@
                <li id="bold"><a href="#" data-key="bold"><u>B</u>old</a></li>
                <li id="italic"><a href="#" data-key="italic"><u>I</u>talic</a></li>
                <li id="underline"><a href="#" data-key="underline"><u>U</u>nderline</a></li>
-               <li id="strikethrough"><a href="#" data-key="Strikethrough">Strikethrough</a></li>
+               <li id="strikethrough"><a href="#" data-key="strikethrough">Strikethrough</a></li>
                <hr></hr>
                <li><a href="#" data-key="insertorderedlist">Ordered List</a></li>
                <li><a href="#" data-key="insertunorderedlist">Unordered list</a></li>


### PR DESCRIPTION
Strike-through wasn't working for me, so I took a peak and noticed it was the only data-key that wasn't all lower-case. I changed the 'S' to an 's' and now everything works great. I'm guessing some web server configurations aren't case-sensitive, or it likely would have been caught earlier :)
