### PR TITLE
Fix: duplicate printPad crashes page load (#34)

### DIFF
--- a/static/js/index.js
+++ b/static/js/index.js
@@ -41,8 +41,7 @@ exports.documentReady = () => {
   });
 };
 
-/* eslint-disable-next-line no-unused-vars */
-const printPad = () => {
+window.printPad = () => {
   const pad = $('iframe[name="ace_outer"]').contents().find('iframe[name="ace_inner"]')[0];
   pad.contentWindow.print();
 };

--- a/templates/toolbar.ejs
+++ b/templates/toolbar.ejs
@@ -120,9 +120,3 @@
 </style>
 
 <script src="../static/js/jquery.js"></script>
-
-<script>
-function printPad(){
-  window.print();
-}
-</script>


### PR DESCRIPTION
## Summary

Fixes #34 — `Uncaught SyntaxError: Identifier 'printPad' has already been declared`

`printPad` was defined in both an inline `<script>` in toolbar.ejs and as `const` in the bundled JS module. esbuild's bundle collided with the inline declaration. Removed the inline script, exposed module function via `window.printPad`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)