### PR TITLE
fix: restore package name so npm publish resolves

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ep_aa_file_menu_toolbar",
+  "name": "ep_file_menu_toolbar",
   "description": "File / Menu style toolbar",
   "version": "0.2.44",
   "author": "johnyma22 (John McLear) <john@mclear.co.uk>",


### PR DESCRIPTION
`package.json` had `"name": "ep_aa_file_menu_toolbar"` but no such package exists on npm (PUT 404). Rename back to `ep_file_menu_toolbar` to match the repo + the previously-published package.