### PR TITLE
fix: backward-compat for ESM etherpad

### DIFF
--- a/eejs.js
+++ b/eejs.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const eejs = require('ep_etherpad-lite/node/eejs/');
+const eejs = require('ep_etherpad-lite/node/eejs');
 
 exports.eejsBlock_styles = (hookName, args, cb) => {
   const css = eejs.require(

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ep_file_menu_toolbar",
   "description": "File / Menu style toolbar",
-  "version": "0.2.53",
+  "version": "0.2.54",
   "author": "johnyma22 (John McLear) <john@mclear.co.uk>",
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
This PR makes the plugin backward-compatible with the upcoming ESM etherpad branch (ether/etherpad#7605).

**Change:** Remove trailing slash from `require("ep_etherpad-lite/node/eejs/")` → `require("ep_etherpad-lite/node/eejs")`

The trailing-slash form breaks under Node's strict ESM exports map resolution. This change is **backward-compatible** with the current CJS etherpad release.